### PR TITLE
Redirect portfolios to directory.gov.au

### DIFF
--- a/site/stag_nginx.conf
+++ b/site/stag_nginx.conf
@@ -67,6 +67,10 @@ http {
     rewrite ^/news-and-social-media/media-releases/latest-media-releases$ https://media.australia.gov.au/mediaRelease redirect;
     rewrite ^/news-and-social-media/media-releases/subscribe-to-the-media-release-service$ https://media.australia.gov.au/subscriber redirect;
 
+    # Redirect to directory.gov.au
+    rewrite ^/directories/australia/portfolio/?$ https://www.directory.gov.au/portfolios/ redirect;
+    rewrite ^/directories/australia/portfolio/(.*)$ https://www.directory.gov.au/portfolios/$1 redirect;
+
     # Redirect to our contact-us page
     rewrite ^/contact-us$ https://www.australia.gov.au/content/help-and-contact-content-page redirect;
 


### PR DESCRIPTION
Feedback received that content is out of date, but this content is not maintained.
Send visitors to directory.gov.au which is maintained by agencies and should be accurate.
