### PR TITLE
Change "Ministry of Arts" to "Department of Communications and the Arts"

### DIFF
--- a/site/public/information-and-services/culture-and-arts.html
+++ b/site/public/information-and-services/culture-and-arts.html
@@ -313,12 +313,12 @@ jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":
       <div class="view-content">
         <div class="views-row views-row-1 web-resource">
       
-  <h2>        <span><a href="https://www.arts.gov.au/">Ministry for the Arts</a></span>  </h2>  
-  <div class="views-field views-field-field-resource-url-1">    <span class="views-label views-label-field-resource-url-1">Download for: </span>    <div class="field-content"><div class="item-list"><ul><li class="first last"><a href="https://www.arts.gov.au/">Ministry for the Arts</a></li>
+  <h2>        <span><a href="https://www.arts.gov.au/">Department of Communications and the Arts</a></span>  </h2>  
+  <div class="views-field views-field-field-resource-url-1">    <span class="views-label views-label-field-resource-url-1">Download for: </span>    <div class="field-content"><div class="item-list"><ul><li class="first last"><a href="https://www.arts.gov.au/">Department of Communications and the Arts</a></li>
 </ul></div></div>  </div>  
   <div>        <div class="landing-description"><p>Provides programs and policies that encourage excellence in art, support for cultural heritage and public access to arts and culture.</p>
 </div>  </div>  
-  <div class="views-field views-field-php-1">        <span class="field-content"><p class='resultURL'>Ministry for the Arts</p></span>  </div>  </div>
+  <div class="views-field views-field-php-1">        <span class="field-content"><p class='resultURL'>Department of Communications and the Arts</p></span>  </div>  </div>
   <div class="views-row views-row-2 web-resource">
       
   <h2>        <span><a href="https://www.australianbiography.gov.au/">Australian Biography</a></span>  </h2>  


### PR DESCRIPTION
Left url for these links as arts.gov.au as this still seems to go to the correct part of the Department's website.