### PR TITLE
Update NSW queen's birthday holiday

### DIFF
--- a/site/public/about-australia/special-dates-and-events/public-holidays.html
+++ b/site/public/about-australia/special-dates-and-events/public-holidays.html
@@ -1031,7 +1031,7 @@
                                       <div class="holiday-title">Anzac Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Wed<span class="number">10</span>Jun</div>
+                                      <div class="holiday-date">Mon<span class="number">8</span>Jun</div>
                                       <div class="holiday-title">Queen's Birthday</div>
                                     </li>
                                     <li class="public-holiday">


### PR DESCRIPTION
Was incorrectly marked as Wednesday 10th of June, 2020.

It should be Mon 8th June