### PR TITLE
QLD part public holiday Christmas Eve

### DIFF
--- a/site/public/about-australia/special-dates-and-events/public-holidays.html
+++ b/site/public/about-australia/special-dates-and-events/public-holidays.html
@@ -1222,6 +1222,10 @@
                                       <div class="holiday-title">Queen's Birthday</div>
                                     </li>
                                     <li class="public-holiday">
+                                      <div class="holiday-date">Tue<span class="number">24</span>Dec</div>
+                                      <div class="holiday-title">Christmas Eve <span class="note">Part-day public holiday from 6pm to midnight</span></div>
+                                    </li>
+                                    <li class="public-holiday">
                                       <div class="holiday-date">Wed<span class="number">25</span>Dec</div>
                                       <div class="holiday-title">Christmas Day</div>
                                     </li>


### PR DESCRIPTION
"On 27 November 2019 an amendment to the Holidays Act 1983 was passed by Parliament providing for a part-day public holiday from 6pm to midnight on Christmas Eve (24 December) to take effect from 2019."
https://www.qld.gov.au/recreation/travel/holidays/public
Right at this moment, the legislation hasn't yet been updated on www.legislation.qld.gov.au

In two minds about editing this, mainly because the page design doesn't really take into account "part-day" holidays 😂