### PR TITLE
Update DFAT media release URLs

### DIFF
--- a/site/public/news-and-social-media/media-releases/media-releases-and-rss-feeds-by-portfolio.html
+++ b/site/public/news-and-social-media/media-releases/media-releases-and-rss-feeds-by-portfolio.html
@@ -17,7 +17,7 @@
   <meta name="DCTERMS.title" content="Media releases and RSS feeds by portfolio">
   <meta name="canonical" content="https://www.australia.gov.au/news-and-social-media/media-releases/media-releases-and-rss-feeds-by-portfolio">
   <meta name="AGOSPTERMS.relatedCategory" content="News and Social Media;news-and-social-media;Media Releases;media-releases;Media releases and RSS feeds by portfolio;media-releases-and-rss-feeds-by-portfolio;" />
-  <meta name="DCTERMS.modified" content="2018-06-19T14:26:21+10:00" schema="DCTERMS.ISO8601" />
+  <meta name="DCTERMS.modified" content="2019-12-02T14:26:21+10:00" schema="DCTERMS.ISO8601" />
   <meta name="DCTERMS.created" content="2013-05-16T08:04:12+10:00" schema="DCTERMS.ISO8601" />
   <meta name="shortlink" content="https://www.australia.gov.au/taxonomy/term/453">
   <meta name="DCTERMS.creator" content="Digital Transformation Agency">
@@ -903,15 +903,16 @@
                                     <h2 id="foreign-affairs">Foreign Affairs and Trade</h2>
                                     <div class="linkList">
                                       <h3>
-                                        <a href="http://foreignminister.gov.au/releases/Pages/default.aspx">Minister for Foreign Affairs</a>
+                                        <a href="https://www.foreignminister.gov.au/minister/marise-payne/media-releases">Minister for Foreign Affairs</a>
                                         <br />
-                                        <a class="rssFeed" href="http://foreignminister.gov.au/foreign.xml">RSS feed</a>
+                                        <a class="rssFeed" href="https://www.foreignminister.gov.au/rss.xml">RSS feed</a>
+                                        <a class="rssFeed" href="https://ministers.dfat.gov.au/rss.xml">RSS feed (Ministers and Assistant Ministers)</a>
                                       </h3>
                                       <p>Senator the Hon Marise Payne</p>
                                       <h3>
-                                        <a href="http://trademinister.gov.au/releases/Pages/default.aspx">Minister for Trade, Tourism and Investment</a>
+                                        <a href="https://www.trademinister.gov.au/minister/simon-birmingham/media-releases">Minister for Trade, Tourism and Investment</a>
                                         <br />
-                                        <a class="rssFeed" href="http://trademinister.gov.au/trade.xml">RSS feed</a>
+                                        <a class="rssFeed" href="https://trademinister.gov.au/rss.xml">RSS feed</a>
                                       </h3>
                                       <p>Senator the Hon Simon Birmingham</p>
                                       <h3>


### PR DESCRIPTION
Updating content in response to request from DFAT:

> DFAT has recently updated our Minister’s websites (migrated to GovCMS) and the RSS feed URLs have changed.
> 
> •	Minister for Foreign Affairs: https://www.foreignminister.gov.au/rss.xml 
> •	Minister for Trade, Tourism and Investment: https://www.trademinister.gov.au/rss.xml
> •	Three (Assistant) Ministers combined: https://ministers.dfat.gov.au/rss.xml
> 
> Can you update these on this webpage: https://www.australia.gov.au/news-and-social-media/media-releases/media-releases-and-rss-feeds-by-portfolio
