### PR TITLE
Fix links in help-and-contact.html

### DIFF
--- a/site/public/help-and-contact.html
+++ b/site/public/help-and-contact.html
@@ -297,7 +297,7 @@
                                   <p class="field-content">
                                     <h3>Quick links to Government</h3>
                                     <ul>
-                                      <li><a href="https://www.directory.gov.au/staticContent.shtml?page=departmentAB">Contact Australian Government departments and agencies</a></li>
+                                      <li><a href="https://www.directory.gov.au/departments-and-agencies">Contact Australian Government departments and agencies</a></li>
                                       <li><a href="/about-government/states-territories-and-local-government">Contact state, territory and local government</a></li>
                                       <li><a href="https://www.pm.gov.au/contact-your-pm">Contact the Prime Minister</a></li>
                                       <li><a href="/about-government/states-territories-and-local-government/state-parliaments-and-members-contacts">State parliaments and members' contact</a></li>
@@ -306,7 +306,7 @@
                                     <ul>
                                       <li><a href="https://www.humanservices.gov.au/customer/contact-us">Human Services</a><br />
                                         (Centrelink, Child Support Agency and Medicare)</li>
-                                      <li><a href="https://www.border.gov.au/about/contact/make-enquiry">Immigration</a></li>
+                                      <li><a href="https://immi.homeaffairs.gov.au/help-support/contact-us">Immigration</a></li>
                                       <li><a href="https://www.ato.gov.au/About-ATO/About-us/Contact-us/">Tax</a></li>
                                       <li><a href="https://www.dva.gov.au/contact">Veterans' Affairs</a></li>
                                     </ul>
@@ -372,12 +372,12 @@
                                     <p><a href="https://www.homeaffairs.gov.au/about/contact/offices-locations">Find contact details for your nearest service centre</a></p>
                                     <hr />
                                     <h2>About myGov</h2>
-                                    <p><strong>If you have a question about a member service</strong> you access on myGov (for example tax or JobSearch) you will need to <a href="https://my.gov.au/mygov/content/html/contact">contact the provider.</a></p>
-                                    <p>Answers to <strong>common questions</strong> about myGov can be found on the <a href="https://my.gov.au/mygov/content/html/help">myGov Need Help?</a> page.</p>
-                                    <p>For <strong>all other questions</strong> contact the <a href="https://my.gov.au/mygov/content/html/contact">myGov helpdesk</a></p>
+                                    <p><strong>If you have a question about a member service</strong> you access on myGov (for example tax or JobSearch) you will need to <a href="https://my.gov.au/mygov/content/html/contact.html">contact the provider.</a></p>
+                                    <p>Answers to <strong>common questions</strong> about myGov can be found on the <a href="https://my.gov.au/mygov/content/html/help.html">myGov Need Help?</a> page.</p>
+                                    <p>For <strong>all other questions</strong> contact the <a href="https://my.gov.au/mygov/content/html/contact.html">myGov helpdesk</a></p>
                                     <hr />
                                     <h2>About tax or superannuation</h2>
-                                    <p><a href="https://www.ato.gov.au/About-ATO/About-us/Contact-us/">Contact the Australian Taxation Office</a></p>
+                                    <p><a href="https://www.ato.gov.au/About-ATO/Contact-us/">Contact the Australian Taxation Office</a></p>
                                     <hr />
                                     <h2>About Patents and Trademarks</h2>
                                     <p><a href="https://www.ipaustralia.gov.au/about-us/contact-us">Contact IP Australia</a></p>
@@ -402,7 +402,7 @@
                                     <p><a href="https://www.australia.gov.au/information-and-services/family-and-community/births-deaths-and-marriages-registries">Births, deaths and marriages registries by state</a></p>
                                     <h3>Police checks</h3>
                                     <p>Contact the relevant state or territory police service</p>
-                                    <p><a href="https://www.australia.gov.au/content/police-checks-criminal-history-records-checks">Police checks by state</a></p>
+                                    <p><a href="https://www.australia.gov.au/information-and-services/public-safety-and-law/police-and-crime-prevention/police-checks">Police checks by state</a></p>
                                     <hr />
                                   </div>
                                 </div>


### PR DESCRIPTION
Fixed dead links:
https://my.gov.au/mygov/content/html/contact --> https://my.gov.au/mygov/content/html/contact.html
https://my.gov.au/mygov/content/html/help --> https://my.gov.au/mygov/content/html/help.html
https://www.australia.gov.au/content/police-checks-criminal-history-records-checks --> https://www.australia.gov.au/information-and-services/public-safety-and-law/police-and-crime-prevention/police-checks
https://www.border.gov.au/about/contact/make-enquiry --> https://immi.homeaffairs.gov.au/help-support/contact-us
https://www.directory.gov.au/staticContent.shtml?page=departmentAB --> https://www.directory.gov.au/departments-and-agencies
https://www.ato.gov.au/About-ATO/About-us/Contact-us/ --> https://www.ato.gov.au/About-ATO/Contact-us/