### PR TITLE
Update deploy slack notification rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ workflows:
                 - develop
                 - master
                 - /.*no-preview/
+                - /.*nopreview/
       - deploy-staging:
           filters:
             branches:

--- a/notify_new_develop_deploy.sh
+++ b/notify_new_develop_deploy.sh
@@ -6,9 +6,9 @@ set -o pipefail
 # Print shell input lines as they are read.
 set -v
 
-# see if last merge commit mentioned release-
-git log --oneline --merges develop | head -n1
-git log --oneline --merges develop | head -n1 | grep release-
+# see if last merge commit mentioned release- or r00- or r000-
+git log --oneline --merges origin/develop | head -n1
+git log --oneline --merges origin/develop | head -n1 | egrep "release-|r\d\d\d?-"
 
 LAST_MERGED_BRANCH_IS_NOT_RELEASE=$?
 if test $LAST_MERGED_BRANCH_IS_NOT_RELEASE -eq 1 # ie. does NOT match == 1 == true

--- a/preview-deploy.sh
+++ b/preview-deploy.sh
@@ -12,15 +12,19 @@ cp config/stag_manifest.yml site/manifest.yml
 cd site
 GITBRANCH="$(git symbolic-ref --short -q HEAD)"
 APPNAME=preview-ausgov-`basename $GITBRANCH`
-cf app $APPNAME > /dev/null
-APP_NEW=$?
+# check if app already deployed
+#cf app $APPNAME > /dev/null
+#APP_NEW=$?
 
 cf push $APPNAME -f manifest.yml
 
-cd "../"
-if test $APP_NEW -eq 1 # ie. does NOT exist == 1 == true
-then
- python3 slack.py --new_preview $APPNAME
-else
-	echo "$APPNAME already existed so no need for slack notification"
-fi
+python3 slack.py --new_preview $APPNAME
+
+# notify only if app wasn't already deployed
+#cd "../"
+#if test $APP_NEW -eq 1 # ie. does NOT exist == 1 == true
+#then
+# python3 slack.py --new_preview $APPNAME
+#else
+#	echo "$APPNAME already existed so no need for slack notification"
+#fi


### PR DESCRIPTION
Allow -nopreview suffix, always notify about new preview deploys and notify on merges of branches that start with "r" and 2 or 3 numbers like r24-14042020