### PR TITLE
Updates to the public holiday and school term date pages.

### DIFF
--- a/site/public/about-australia/special-dates-and-events/public-holidays.html
+++ b/site/public/about-australia/special-dates-and-events/public-holidays.html
@@ -909,60 +909,64 @@
                                 <div>
                                   <h2 id="nsw">New South Wales</h2>
                                   <div class="date-source">Source:
-                                    <p><a href="http://www.industrialrelations.nsw.gov.au/oirwww/NSW_public_holidays/NSW_Public_Holidays.page?">http://www.industrialrelations.nsw.gov.au/oirwww/NSW_public_holidays/NSW_Public_Holidays.page?</a></p>
-                                  </div>                                  
-                                  <h3>2020</h3>
+                                    <p><a href="https://www.industrialrelations.nsw.gov.au/oirwww/NSW_public_holidays/NSW_Public_Holidays.page">https://www.industrialrelations.nsw.gov.au/oirwww/NSW_public_holidays/NSW_Public_Holidays.page?</a></p>
+                                  </div>
+                                  <h3>2021</h3>
                                   <ul class="public-holidays nsw-2020">
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Wed<span class="number">1</span>Jan</div>
+                                      <div class="holiday-date">Fri<span class="number">1</span>Jan</div>
                                       <div class="holiday-title">New Year's Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">27</span>Jan</div>
-                                      <div class="holiday-title">Australia Day <span class="note">As 26 January falls on a Sunday, the following Monday is observed</span></div>
+                                      <div class="holiday-date">Tue<span class="number">26</span>Jan</div>
+                                      <div class="holiday-title">Australia Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">10</span>Apr</div>
+                                      <div class="holiday-date">Fri<span class="number">2</span>Apr</div>
                                       <div class="holiday-title">Good Friday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">11</span>Apr</div>
+                                      <div class="holiday-date">Sat<span class="number">3</span>Apr</div>
                                       <div class="holiday-title">Easter Saturday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sun<span class="number">12</span>Apr</div>
+                                      <div class="holiday-date">Sun<span class="number">4</span>Apr</div>
                                       <div class="holiday-title">Easter Sunday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">13</span>Apr</div>
+                                      <div class="holiday-date">Mon<span class="number">5</span>Apr</div>
                                       <div class="holiday-title">Easter Monday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">25</span>Apr</div>
+                                      <div class="holiday-date">Sun<span class="number">25</span>Apr</div>
                                       <div class="holiday-title">Anzac Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">8</span>Jun</div>
+                                      <div class="holiday-date">Mon<span class="number">14</span>Jun</div>
                                       <div class="holiday-title">Queen's Birthday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">3</span>Aug</div>
+                                      <div class="holiday-date">Mon<span class="number">2</span>Aug</div>
                                       <div class="holiday-title">Bank Holiday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">5</span>Oct</div>
+                                      <div class="holiday-date">Mon<span class="number">4</span>Oct</div>
                                       <div class="holiday-title">Labour Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">25</span>Dec</div>
+                                      <div class="holiday-date">Sat<span class="number">25</span>Dec</div>
                                       <div class="holiday-title">Christmas Day </div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">26</span>Dec</div>
+                                      <div class="holiday-date">Sun<span class="number">26</span>Dec</div>
                                       <div class="holiday-title">Boxing Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">28</span>Dec</div>
+                                      <div class="holiday-date">Mon<span class="number">27</span>Dec</div>
+                                      <div class="holiday-title">Christmas Day (Additional day)</div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Tue<span class="number">28</span>Dec</div>
                                       <div class="holiday-title">Boxing Day (Additional day)</div>
                                     </li>
                                   </ul>

--- a/site/public/about-australia/special-dates-and-events/public-holidays.html
+++ b/site/public/about-australia/special-dates-and-events/public-holidays.html
@@ -29,7 +29,7 @@
   <link rel="apple-touch-icon" sizes="152x152" href="/profiles/gsecms/themes/ausgovau_bootstrap/favicons/apple-touch-icon-152x152.png">
   <link rel="apple-touch-icon" sizes="180x180" href="/profiles/gsecms/themes/ausgovau_bootstrap/favicons/apple-touch-icon-180x180.png">
   <link rel="icon" type="image/png" href="/profiles/gsecms/themes/ausgovau_bootstrap/favicons/favicon-32x32.png" sizes="32x32">
-  
+
   <link rel="icon" type="image/png" href="/profiles/gsecms/themes/ausgovau_bootstrap/favicons/favicon-96x96.png" sizes="96x96">
   <link rel="icon" type="image/png" href="/profiles/gsecms/themes/ausgovau_bootstrap/favicons/favicon-16x16.png" sizes="16x16">
   <link rel="manifest" href="/profiles/gsecms/themes/ausgovau_bootstrap/favicons/manifest.json">

--- a/site/public/about-australia/special-dates-and-events/public-holidays.html
+++ b/site/public/about-australia/special-dates-and-events/public-holidays.html
@@ -1325,56 +1325,60 @@
                                 <div>
                                   <h2 id="wa">Western Australia</h2>
                                   <div class="date-source">Source:
-                                    <p><a href="http://www.commerce.wa.gov.au/labour-relations/public-holidays-western-australia">http://www.commerce.wa.gov.au/labour-relations/public-holidays-western-australia</a></p>
+                                    <p><a href="https://www.commerce.wa.gov.au/labour-relations/public-holidays-western-australia">https://www.commerce.wa.gov.au/labour-relations/public-holidays-western-australia</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="public-holidays wa-2020">
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Wed<span class="number">1</span>Jan</div>
+                                      <div class="holiday-date">Fri<span class="number">1</span>Jan</div>
                                       <div class="holiday-title">New Year's Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">27</span>Jan</div>
-                                      <div class="holiday-title">Australia Day <span class="note">As 26 January falls on a Sunday, the following Monday is observed</span></div>
+                                      <div class="holiday-date">Tue<span class="number">26</span>Jan</div>
+                                      <div class="holiday-title">Australia Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">2</span>Mar</div>
+                                      <div class="holiday-date">Mon<span class="number">1</span>Mar</div>
                                       <div class="holiday-title">Labour Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">10</span>Apr</div>
+                                      <div class="holiday-date">Fri<span class="number">2</span>Apr</div>
                                       <div class="holiday-title">Good Friday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">13</span>Apr</div>
+                                      <div class="holiday-date">Mon<span class="number">5</span>Apr</div>
                                       <div class="holiday-title">Easter Monday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">25</span>Apr</div>
+                                      <div class="holiday-date">Sun<span class="number">25</span>Apr</div>
                                       <div class="holiday-title">Anzac Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">27</span>Apr</div>
-                                      <div class="holiday-title">Anzac Day</div>
+                                      <div class="holiday-date">Mon<span class="number">26</span>Apr</div>
+                                      <div class="holiday-title">Anzac Day (Additional day)</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">1</span>Jun</div>
+                                      <div class="holiday-date">Mon<span class="number">7</span>Jun</div>
                                       <div class="holiday-title">Western Australia Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">28</span>Sep</div>
+                                      <div class="holiday-date">Mon<span class="number">27</span>Sep</div>
                                       <div class="holiday-title">Queen's Birthday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">25</span>Dec</div>
+                                      <div class="holiday-date">Sat<span class="number">25</span>Dec</div>
                                       <div class="holiday-title">Christmas Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">26</span>Dec</div>
+                                      <div class="holiday-date">Sun<span class="number">26</span>Dec</div>
                                       <div class="holiday-title">Boxing Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">28</span>Dec</div>
+                                      <div class="holiday-date">Mon<span class="number">27</span>Dec</div>
+                                      <div class="holiday-title">Christmas Day (Additional day)/div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Tue<span class="number">28</span>Dec</div>
                                       <div class="holiday-title">Boxing Day (Additional day)</div>
                                     </li>
                                   </ul>

--- a/site/public/about-australia/special-dates-and-events/public-holidays.html
+++ b/site/public/about-australia/special-dates-and-events/public-holidays.html
@@ -1121,65 +1121,69 @@
                                 <div>
                                   <h2 id="sa">South Australia</h2>
                                   <div class="date-source">Source:
-                                    <p><a href="http://www.safework.sa.gov.au/show_page.jsp?id=2483">http://www.safework.sa.gov.au/show_page.jsp?id=2483</a></p>
+                                    <p><a href="https://www.safework.sa.gov.au/resources/public-holidays">https://www.safework.sa.gov.au/resources/public-holidays</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="public-holidays sa-2020">
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Wed<span class="number">1</span>Jan</div>
+                                      <div class="holiday-date">Fri<span class="number">1</span>Jan</div>
                                       <div class="holiday-title">New Year's Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sun<span class="number">26</span>Jan</div>
+                                      <div class="holiday-date">Tue<span class="number">26</span>Jan</div>
                                       <div class="holiday-title">Australia Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">27</span>Jan</div>
-                                      <div class="holiday-title">Australia Day (Additional day)</div>
-                                    </li>
-                                    <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">9</span>Mar</div>
+                                      <div class="holiday-date">Mon<span class="number">8</span>Mar</div>
                                       <div class="holiday-title">Adelaide Cup Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">10</span>Apr</div>
+                                      <div class="holiday-date">Fri<span class="number">2</span>Apr</div>
                                       <div class="holiday-title">Good Friday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">11</span>Apr</div>
+                                      <div class="holiday-date">Sat<span class="number">3</span>Apr</div>
                                       <div class="holiday-title">Easter Saturday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">13</span>Apr</div>
+                                      <div class="holiday-date">Mon<span class="number">5</span>Apr</div>
                                       <div class="holiday-title">Easter Monday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">25</span>Apr</div>
+                                      <div class="holiday-date">Mon<span class="number">26</span>Apr</div>
                                       <div class="holiday-title">Anzac Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">8</span>Jun</div>
+                                      <div class="holiday-date">Mon<span class="number">14</span>Jun</div>
                                       <div class="holiday-title">Queen's Birthday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">5</span>Oct</div>
+                                      <div class="holiday-date">Mon<span class="number">4</span>Oct</div>
                                       <div class="holiday-title">Labour Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Thu<span class="number">24</span>Dec</div>
-                                      <div class="holiday-title">Christmas Eve</div>
+                                      <div class="holiday-date">Fri<span class="number">24</span>Dec</div>
+                                      <div class="holiday-title">Christmas Eve <span class="note">Part-day public holiday (7pm to midnight).</span></div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">25</span>Dec</div>
+                                      <div class="holiday-date">Sat<span class="number">25</span>Dec</div>
                                       <div class="holiday-title">Christmas Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">28</span>Dec</div>
-                                      <div class="holiday-title">Proclamation Day </div>
+                                      <div class="holiday-date">Sun<span class="number">26</span>Dec</div>
+                                      <div class="holiday-title">Boxing Day / Proclamation Day</div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Mon<span class="number">27</span>Dec</div>
+                                      <div class="holiday-title">Christmas Day (Additional day)</div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Tue<span class="number">28</span>Dec</div>
+                                      <div class="holiday-title">Boxing Day / Proclamation Day (Additional day)</div>
                                     </li>
                                     <li class="public-holiday">
                                       <div class="holiday-date">Thu<span class="number">31</span>Dec</div>
-                                      <div class="holiday-title">New Year's Eve</div>
+                                      <div class="holiday-title">New Year's Eve <span class="note">Part-day public holiday (7pm to midnight).</span></div>
                                     </li>
                                   </ul>
                                   <div class="back-to-top"><a href="public-holidays.html#top">Go to top</a></div>

--- a/site/public/about-australia/special-dates-and-events/public-holidays.html
+++ b/site/public/about-australia/special-dates-and-events/public-holidays.html
@@ -977,36 +977,36 @@
                                 <div>
                                   <h2 id="nt">Northern Territory</h2>
                                   <div class="date-source">Source:
-                                    <p><a href="https://nt.gov.au/employ/for-employees-in-nt/nt-public-holidays">https://nt.gov.au/employ/for-employees-in-nt/nt-public-holidays</a></p>
+                                    <p><a href="https://nt.gov.au/nt-public-holidays">https://nt.gov.au/nt-public-holidays</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="public-holidays nt-2020">
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Wed<span class="number">1</span>Jan</div>
+                                      <div class="holiday-date">Fri<span class="number">1</span>Jan</div>
                                       <div class="holiday-title">New Year's Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">27</span>Jan</div>
-                                      <div class="holiday-title">Australia Day <span class="note">As 26 January falls on a Sunday, the following Monday is observed</span></div>
+                                      <div class="holiday-date">Tue<span class="number">26</span>Jan</div>
+                                      <div class="holiday-title">Australia Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">10</span>Apr</div>
+                                      <div class="holiday-date">Fri<span class="number">2</span>Apr</div>
                                       <div class="holiday-title">Good Friday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">11</span>Apr</div>
+                                      <div class="holiday-date">Sat<span class="number">3</span>Apr</div>
                                       <div class="holiday-title">Saturday before Easter Sunday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">13</span>Apr</div>
+                                      <div class="holiday-date">Mon<span class="number">5</span>Apr</div>
                                       <div class="holiday-title">Easter Monday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">25</span>Apr</div>
+                                      <div class="holiday-date">Mon<span class="number">26</span>Apr</div>
                                       <div class="holiday-title">Anzac Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">4</span>May</div>
+                                      <div class="holiday-date">Mon<span class="number">3</span>May</div>
                                       <div class="holiday-title">May Day</div>
                                     </li>
                                     <li class="public-holiday">
@@ -1014,24 +1014,32 @@
                                       <div class="holiday-title">Queen's Birthday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">3</span>Aug</div>
+                                      <div class="holiday-date">Mon<span class="number">2</span>Aug</div>
                                       <div class="holiday-title">Picnic Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Thu<span class="number">24</span>Dec</div>
-                                      <div class="holiday-title">Christmas Eve</div>
+                                      <div class="holiday-date">Fri<span class="number">24</span>Dec</div>
+                                      <div class="holiday-title">Christmas Eve <span class="note">Part-day holiday 7pm to midnight.</span></div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">25</span>Dec</div>
+                                      <div class="holiday-date">Sat<span class="number">25</span>Dec</div>
                                       <div class="holiday-title">Christmas Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">28</span>Dec</div>
+                                      <div class="holiday-date">Sun<span class="number">26</span>Dec</div>
                                       <div class="holiday-title">Boxing Day</div>
                                     </li>
                                     <li class="public-holiday">
+                                      <div class="holiday-date">Mon<span class="number">27</span>Dec</div>
+                                      <div class="holiday-title">Christmas Day (Additional day)</div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Tue<span class="number">28</span>Dec</div>
+                                      <div class="holiday-title">Boxing Day (Additional day)</div>
+                                    </li>
+                                    <li class="public-holiday">
                                       <div class="holiday-date">Thu<span class="number">31</span>Dec</div>
-                                      <div class="holiday-title">New Year's Eve</div>
+                                      <div class="holiday-title">New Year's Eve <span class="note">Part-day holiday 7pm to midnight.</span></div>
                                     </li>
                                   </ul>
                                   <div class="back-to-top"><a href="public-holidays.html#top">Go to top</a></div>

--- a/site/public/about-australia/special-dates-and-events/public-holidays.html
+++ b/site/public/about-australia/special-dates-and-events/public-holidays.html
@@ -833,36 +833,36 @@
                                 <div>
                                   <h2 id="act">Australian Capital Territory</h2>
                                   <div class="date-source">Source:
-                                    <p><a href="http://www.cmd.act.gov.au/communication/holidays">http://www.cmd.act.gov.au/communication/holidays</a></p>
+                                    <p><a href="https://www.cmd.act.gov.au/communication/holidays">https://www.cmd.act.gov.au/communication/holidays</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="public-holidays act-2020">
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Wed<span class="number">1</span>Jan</div>
+                                      <div class="holiday-date">Fri<span class="number">1</span>Jan</div>
                                       <div class="holiday-title">New Year's Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">27</span>Jan</div>
-                                      <div class="holiday-title">Australia Day <span class="note">As 26 January falls on a Sunday, the following Monday is observed</span></div>
+                                      <div class="holiday-date">Tue<span class="number">26</span>Jan</div>
+                                      <div class="holiday-title">Australia Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">9</span>Mar</div>
+                                      <div class="holiday-date">Mon<span class="number">8</span>Mar</div>
                                       <div class="holiday-title">Canberra Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">10</span>Apr</div>
+                                      <div class="holiday-date">Fri<span class="number">2</span>Apr</div>
                                       <div class="holiday-title">Good Friday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">11</span>Apr</div>
+                                      <div class="holiday-date">Sat<span class="number">3</span>Apr</div>
                                       <div class="holiday-title">Easter Saturday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sun<span class="number">12</span>Apr</div>
+                                      <div class="holiday-date">Sun<span class="number">4</span>Apr</div>
                                       <div class="holiday-title">Easter Sunday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">13</span>Apr</div>
+                                      <div class="holiday-date">Mon<span class="number">5</span>Apr</div>
                                       <div class="holiday-title">Easter Monday</div>
                                     </li>
                                     <li class="public-holiday">
@@ -871,27 +871,35 @@
                                     </li>
                                     <li class="public-holiday">
                                       <div class="holiday-date">Mon<span class="number">27</span>Apr</div>
-                                      <div class="holiday-title">Declared public holiday <span class="note">Monday, 27 April 2020 has been declared a public holiday in the ACT and Western Australia. The 27 April 2020 public holiday is in addition to the ANZAC Day public holiday on 25 April 2020.</span></div>
+                                      <div class="holiday-title">Declared public holiday <span class="note">As 25 April (ANZAC Day) falls on a Sunday in 2021, the following Monday is observed as a public holiday.</span></div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">1</span>Jun</div>
+                                      <div class="holiday-date">Mon<span class="number">31</span>May</div>
                                       <div class="holiday-title">Reconciliation Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">8</span>Jun</div>
+                                      <div class="holiday-date">Mon<span class="number">14</span>Jun</div>
                                       <div class="holiday-title">Queen's Birthday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">5</span>Oct</div>
+                                      <div class="holiday-date">Mon<span class="number">4</span>Oct</div>
                                       <div class="holiday-title">Labour Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">25</span>Dec</div>
+                                      <div class="holiday-date">Sat<span class="number">25</span>Dec</div>
                                       <div class="holiday-title">Christmas Day </div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">28</span>Dec</div>
-                                      <div class="holiday-title">Boxing Day</div>
+                                      <div class="holiday-date">Sun<span class="number">26</span>Dec</div>
+                                      <div class="holiday-title">Boxing Day </div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Mon<span class="number">27</span>Dec</div>
+                                      <div class="holiday-title">Christmas Day (Additional day)</div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Tue<span class="number">28</span>Dec</div>
+                                      <div class="holiday-title">Boxing Day (Additional day)</div>
                                     </li>
                                   </ul>
                                   <div class="back-to-top"><a href="public-holidays.html#top">Go to top</a></div>

--- a/site/public/about-australia/special-dates-and-events/public-holidays.html
+++ b/site/public/about-australia/special-dates-and-events/public-holidays.html
@@ -1193,49 +1193,57 @@
                                 <div>
                                   <h2 id="tas">Tasmania</h2>
                                   <div class="date-source">Source:
-                                    <p><a href="http://worksafe.tas.gov.au/laws/public_holidays">http://worksafe.tas.gov.au/laws/public_holidays</a></p>
+                                    <p><a href="https://worksafe.tas.gov.au/topics/laws-and-compliance/public-holidays">https://worksafe.tas.gov.au/topics/laws-and-compliance/public-holidays</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="public-holidays tas-2020">
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Wed<span class="number">1</span>Jan</div>
+                                      <div class="holiday-date">Fri<span class="number">1</span>Jan</div>
                                       <div class="holiday-title">New Year's Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">27</span>Jan</div>
-                                      <div class="holiday-title">Australia Day <span class="note">As 26 January falls on a Sunday, the following Monday is observed</span></div>
+                                      <div class="holiday-date">Tue<span class="number">26</span>Jan</div>
+                                      <div class="holiday-title">Australia Day </div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">9</span>Mar</div>
+                                      <div class="holiday-date">Mon<span class="number">8</span>Mar</div>
                                       <div class="holiday-title">Eight Hours Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">10</span>Apr</div>
+                                      <div class="holiday-date">Fri<span class="number">2</span>Apr</div>
                                       <div class="holiday-title">Good Friday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">13</span>Apr</div>
+                                      <div class="holiday-date">Mon<span class="number">5</span>Apr</div>
                                       <div class="holiday-title">Easter Monday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Tue<span class="number">14</span>Apr</div>
+                                      <div class="holiday-date">Tue<span class="number">6</span>Apr</div>
                                       <div class="holiday-title">Easter Tuesday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">25</span>Apr</div>
+                                      <div class="holiday-date">Mon<span class="number">26</span>Apr</div>
                                       <div class="holiday-title">Anzac Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">8</span>Jun</div>
+                                      <div class="holiday-date">Mon<span class="number">14</span>Jun</div>
                                       <div class="holiday-title">Queen's Birthday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">25</span>Dec</div>
+                                      <div class="holiday-date">Sat<span class="number">25</span>Dec</div>
                                       <div class="holiday-title">Christmas Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">28</span>Dec</div>
+                                      <div class="holiday-date">Sun<span class="number">26</span>Dec</div>
                                       <div class="holiday-title">Boxing Day</div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Mon<span class="number">27</span>Dec</div>
+                                      <div class="holiday-title">Christmas Day (Additional day)</div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Sun<span class="number">28</span>Dec</div>
+                                      <div class="holiday-title">Boxing Day (Additional day)</div>
                                     </li>
                                   </ul>
                                   <div class="back-to-top"><a href="public-holidays.html#top">Go to top</a></div>

--- a/site/public/about-australia/special-dates-and-events/public-holidays.html
+++ b/site/public/about-australia/special-dates-and-events/public-holidays.html
@@ -1253,64 +1253,68 @@
                                 <div>
                                   <h2 id="vic">Victoria</h2>
                                   <div class="date-source">Source:
-                                    <p><a href="http://www.business.vic.gov.au/victorian-public-holidays-and-daylight-saving/victorian-public-holidays">http://www.business.vic.gov.au/victorian-public-holidays-and-daylight-saving/victorian-public-holidays</a></p>
+                                    <p><a href="https://www.business.vic.gov.au/victorian-public-holidays-and-daylight-saving/victorian-public-holidays">https://www.business.vic.gov.au/victorian-public-holidays-and-daylight-saving/victorian-public-holidays</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="public-holidays vic-2020">
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Wed<span class="number">1</span>Jan</div>
+                                      <div class="holiday-date">Fri<span class="number">1</span>Jan</div>
                                       <div class="holiday-title">New Year's Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">27</span>Jan</div>
-                                      <div class="holiday-title">Australia Day <span class="note">As 26 January falls on a Sunday, the following Monday is observed</span></div>
+                                      <div class="holiday-date">Tue<span class="number">26</span>Jan</div>
+                                      <div class="holiday-title">Australia Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">9</span>Mar</div>
+                                      <div class="holiday-date">Mon<span class="number">8</span>Mar</div>
                                       <div class="holiday-title">Labour Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">10</span>Apr</div>
+                                      <div class="holiday-date">Fri<span class="number">2</span>Apr</div>
                                       <div class="holiday-title">Good Friday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">11</span>Apr</div>
+                                      <div class="holiday-date">Sat<span class="number">3</span>Apr</div>
                                       <div class="holiday-title">Saturday before Easter Sunday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sun<span class="number">12</span>Apr</div>
+                                      <div class="holiday-date">Sun<span class="number">4</span>Apr</div>
                                       <div class="holiday-title">Easter Sunday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">13</span>Apr</div>
+                                      <div class="holiday-date">Mon<span class="number">5</span>Apr</div>
                                       <div class="holiday-title">Easter Monday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">25</span>Apr</div>
-                                      <div class="holiday-title">Anzac Day</div>
+                                      <div class="holiday-date">Sun<span class="number">25</span>Apr</div>
+                                      <div class="holiday-title">Anzac Day <span class="note">Anzac Day is commemorated on the day it falls. There is no replacement holiday when Anzac Day falls on a weekend.</span></div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">8</span>Jun</div>
+                                      <div class="holiday-date">Mon<span class="number">14</span>Jun</div>
                                       <div class="holiday-title">Queen's Birthday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">25</span>Sep</div>
-                                      <div class="holiday-title">Friday before AFL Grand Final</div>
+                                      <div class="holiday-date">Fri<span class="number">24</span>Sep</div>
+                                      <div class="holiday-title">Friday before AFL Grand Final <span class="note">Subject AFL schedule. Typically falls on the last Friday of September.</span></div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Tue<span class="number">3</span>Nov</div>
+                                      <div class="holiday-date">Tue<span class="number">2</span>Nov</div>
                                       <div class="holiday-title">Melbourne Cup</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">25</span>Dec</div>
+                                      <div class="holiday-date">Sat<span class="number">25</span>Dec</div>
                                       <div class="holiday-title">Christmas Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">26</span>Dec</div>
+                                      <div class="holiday-date">Sun<span class="number">26</span>Dec</div>
                                       <div class="holiday-title">Boxing Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">28</span>Dec</div>
+                                      <div class="holiday-date">Mon<span class="number">27</span>Dec</div>
+                                      <div class="holiday-title">Christmas Day (Additional day)</div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Tue<span class="number">28</span>Dec</div>
                                       <div class="holiday-title">Boxing Day (Additional day)</div>
                                     </li>
                                   </ul>

--- a/site/public/about-australia/special-dates-and-events/public-holidays.html
+++ b/site/public/about-australia/special-dates-and-events/public-holidays.html
@@ -1049,12 +1049,12 @@
                                 <div>
                                   <h2 id="qld">Queensland</h2>
                                   <div class="date-source">Source:
-                                    <p><a href="http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates">https://www.qld.gov.au/recreation/travel/holidays/public/</a></p>
+                                    <p><a href="https://www.qld.gov.au/recreation/travel/holidays/public">https://www.qld.gov.au/recreation/travel/holidays/public</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="public-holidays qld-2020">
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Wed<span class="number">1</span>Jan</div>
+                                      <div class="holiday-date">Fri<span class="number">1</span>Jan</div>
                                       <div class="holiday-title">New Year's Day</div>
                                     </li>
                                     <li class="public-holiday">
@@ -1062,43 +1062,55 @@
                                       <div class="holiday-title">Australia Day <span class="note">As 26 January falls on a Sunday, the following Monday is observed</span></div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">10</span>Apr</div>
+                                      <div class="holiday-date">Fri<span class="number">2</span>Apr</div>
                                       <div class="holiday-title">Good Friday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">11</span>Apr</div>
-                                      <div class="holiday-title">Easter Saturday</div>
+                                      <div class="holiday-date">Sat<span class="number">3</span>Apr</div>
+                                      <div class="holiday-title">The day after Good Friday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sun<span class="number">12</span>Apr</div>
+                                      <div class="holiday-date">Sun<span class="number">4</span>Apr</div>
                                       <div class="holiday-title">Easter Sunday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">13</span>Apr</div>
+                                      <div class="holiday-date">Mon<span class="number">5</span>Apr</div>
                                       <div class="holiday-title">Easter Monday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">25</span>Apr</div>
+                                      <div class="holiday-date">Tue<span class="number">26</span>Apr</div>
                                       <div class="holiday-title">Anzac Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">4</span>May</div>
+                                      <div class="holiday-date">Mon<span class="number">3</span>May</div>
                                       <div class="holiday-title">Labour Day</div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Wed<span class="number">11</span>Aug</div>
+                                      <div class="holiday-title">Royal Queensland Show <span class="note">Brisbane area only.</span></div>
                                     </li>
                                     <li class="public-holiday">
                                       <div class="holiday-date">Mon<span class="number">5</span>Oct</div>
                                       <div class="holiday-title">Queen's Birthday</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Fri<span class="number">25</span>Dec</div>
+                                      <div class="holiday-date">Fri<span class="number">24</span>Dec</div>
+                                      <div class="holiday-title">Christmas Eve <span class="note">Part-day holiday 6pm to midnight.</span></div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Sat<span class="number">25</span>Dec</div>
                                       <div class="holiday-title">Christmas Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Sat<span class="number">26</span>Dec</div>
+                                      <div class="holiday-date">Sun<span class="number">26</span>Dec</div>
                                       <div class="holiday-title">Boxing Day</div>
                                     </li>
                                     <li class="public-holiday">
-                                      <div class="holiday-date">Mon<span class="number">28</span>Dec</div>
+                                      <div class="holiday-date">Mon<span class="number">27</span>Dec</div>
+                                      <div class="holiday-title">Christmas Day (Additional day)</div>
+                                    </li>
+                                    <li class="public-holiday">
+                                      <div class="holiday-date">Tue<span class="number">28</span>Dec</div>
                                       <div class="holiday-title">Boxing Day (Additional day)</div>
                                     </li>
                                   </ul>

--- a/site/public/about-australia/special-dates-and-events/school-term-dates.html
+++ b/site/public/about-australia/special-dates-and-events/school-term-dates.html
@@ -496,23 +496,23 @@
                                   <h2 id="qld">Queensland</h2>
                                   <div class="date-source">Source: <p><a href="https://education.qld.gov.au/about-us/calendar/term-dates">https://education.qld.gov.au/about-us/calendar/term-dates</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="school-terms qld-2020">
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">1</span>2020</div>
-                                      <div class="term-dates">Tue 28 Jan 2020 &ndash; Fri 3 Apr 2020</div>
+                                      <div class="term-name">Term<span class="number">1</span>2021</div>
+                                      <div class="term-dates">Wed 27 Jan 2021 &ndash; Thur 1 Apr 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">2</span>2020</div>
-                                      <div class="term-dates">Mon 20 Apr 2020 &ndash; Fri 26 Jun 2020</div>
+                                      <div class="term-name">Term<span class="number">2</span>2021</div>
+                                      <div class="term-dates">Mon 19 Apr 2021 &ndash; Fri 25 Jun 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">3</span>2020</div>
-                                      <div class="term-dates">Mon 13 Jul 2020 &ndash; Fri 18 Sep 2020</div>
+                                      <div class="term-name">Term<span class="number">3</span>2021</div>
+                                      <div class="term-dates">Mon 12 Jul 2021 &ndash; Fri 17 Sep 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">4</span>2020</div>
-                                      <div class="term-dates">Tue 6 Oct 2020 &ndash; Fri 11 Dec 2020<span class="note">Year 12 - 20 November 2020; Year 10 & 11 - 27 November 2020.</span></div>
+                                      <div class="term-name">Term<span class="number">4</span>2021</div>
+                                      <div class="term-dates">Tue 5 Oct 2021 &ndash; Fri 10 Dec 2021<span class="note">Year 12 - 19 November 2021; Year 10 & 11 - 26 November 2021.</span></div>
                                     </li>
                                   </ul>
                                   <div class="back-to-top"><a href="school-term-dates.html#top">Go to top</a></div>

--- a/site/public/about-australia/special-dates-and-events/school-term-dates.html
+++ b/site/public/about-australia/special-dates-and-events/school-term-dates.html
@@ -467,33 +467,25 @@
                               <div class="views-row views-row-3">
                                 <div>
                                   <h2 id="nt">Northern Territory</h2>
-                                  <div class="date-source">Source: <p><a href="https://www.education.nt.gov.au/students/at-school/term-dates">http://www.education.nt.gov.au/students/at-school/term-dates</a></p>
+                                  <div class="date-source">Source: <p><a href="https://nt.gov.au/learning/primary-and-secondary-students/school-term-dates-in-nt">https://nt.gov.au/learning/primary-and-secondary-students/school-term-dates-in-nt</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="school-terms nt-2020">
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">1</span>2020</div>
-                                      <div class="term-dates">Tue 28 Jan 2020 &ndash; Thu 9 Apr 2020<span class="note">Urban Schools</span></div>
+                                      <div class="term-name">Term<span class="number">1</span>2021</div>
+                                      <div class="term-dates">Mon 1 Feb 2021 &ndash; Fri 9 Apr 2021 <span class="note">Remote schools (except Gunbalanya School) start Tue 2 Feb.</span></div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">1</span>2020</div>
-                                      <div class="term-dates">Wed 29 Jan 2020 &ndash; Thu 9 Apr 2020<span class="note">Remote Schools</span></div>
+                                      <div class="term-name">Term<span class="number">2</span>2021</div>
+                                      <div class="term-dates">Mon 19 Apr 2021 &ndash; Fri 25 Jun 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">2</span>2020</div>
-                                      <div class="term-dates">Mon 20 Apr 2020 &ndash; Fri 26 Jun 2020</div>
+                                      <div class="term-name">Term<span class="number">3</span>2021</div>
+                                      <div class="term-dates">Tue 20 Jul 2021 &ndash; Fri 24 Sep 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">3</span>2020</div>
-                                      <div class="term-dates">Tue 21 Jul 2020 &ndash; Fri 25 Sep 2020</div>
-                                    </li>
-                                    <li class="school-term">
-                                      <div class="term-name">Term<span class="number">4 </span>2020</div>
-                                      <div class="term-dates">Mon 12 Oct 2020 &ndash; Thu 17 Dec 2020<span class="note">Urban schools</span></div>
-                                    </li>
-                                    <li class="school-term">
-                                      <div class="term-name">Term<span class="number">4</span>2020</div>
-                                      <div class="term-dates">Mon 12 Oct 2020 &ndash; Fri 18 Dec 2020<span class="note">Remote schools</span></div>
+                                      <div class="term-name">Term<span class="number">4 </span>2021</div>
+                                      <div class="term-dates">Mon 11 Oct 2021 &ndash; Thu 16 Dec 2021<span class="note">Remote schools finish Fri 17 Dec.</span></div>
                                     </li>
                                   </ul>
                                   <div class="back-to-top"><a href="school-term-dates.html#top">Go to top</a></div>

--- a/site/public/about-australia/special-dates-and-events/school-term-dates.html
+++ b/site/public/about-australia/special-dates-and-events/school-term-dates.html
@@ -523,23 +523,23 @@
                                   <h2 id="sa">South Australia</h2>
                                   <div class="date-source">Source: <p><a href="https://www.education.sa.gov.au/teaching/south-australian-state-schools-term-dates">https://www.education.sa.gov.au/teaching/south-australian-state-schools-term-dates</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="school-terms sa-2020">
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">1</span>2020</div>
-                                      <div class="term-dates">Tue 28 Jan 2020 &ndash; Thu 9 Apr 2020</div>
+                                      <div class="term-name">Term<span class="number">1</span>2021</div>
+                                      <div class="term-dates">Wed 27 Jan 2021 &ndash; Fri 9 Apr 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">2</span>2020</div>
-                                      <div class="term-dates">Mon 27 Apr 2020 &ndash; Fri 3 Jul 2020</div>
+                                      <div class="term-name">Term<span class="number">2</span>2021</div>
+                                      <div class="term-dates">Tue 27 Apr 2021 &ndash; Fri 2 Jul 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">3</span>2020</div>
-                                      <div class="term-dates">Mon 20 Jul 2020 &ndash; Fri 25 Sep 2020</div>
+                                      <div class="term-name">Term<span class="number">3</span>2021</div>
+                                      <div class="term-dates">Mon 19 Jul 2021 &ndash; Fri 24 Sep 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">4</span>2020</div>
-                                      <div class="term-dates">Mon 12 Oct 2020 &ndash; Fri 11 Dec 2020</div>
+                                      <div class="term-name">Term<span class="number">4</span>2021</div>
+                                      <div class="term-dates">Mon 11 Oct 2021 &ndash; Fri 10 Dec 2021</div>
                                     </li>
                                   </ul>
                                   <div class="back-to-top"><a href="school-term-dates.html#top">Go to top</a></div>

--- a/site/public/about-australia/special-dates-and-events/school-term-dates.html
+++ b/site/public/about-australia/special-dates-and-events/school-term-dates.html
@@ -550,23 +550,23 @@
                                   <h2 id="tas">Tasmania</h2>
                                   <div class="date-source">Source: <p><a href="https://www.education.tas.gov.au/about-us/term-dates/">https://www.education.tas.gov.au/about-us/term-dates/</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="school-terms tas-2020">
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">1</span>2020</div>
-                                      <div class="term-dates">Wed 5 Feb 2020 &ndash; Thu 9 Apr 2020<span class="note">Teachers commence Mon 3 February 2020</span></div>
+                                      <div class="term-name">Term<span class="number">1</span>2021</div>
+                                      <div class="term-dates">Wed 3 Feb 2021 &ndash; Wed 31 Mar 2021<span class="note">Colleges finish Thu 1 April.</span></div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">2</span>2020</div>
-                                      <div class="term-dates">Mon 27 Apr 2020 &ndash; Fri 3 Jul 2020</div>
+                                      <div class="term-name">Term<span class="number">2</span>2021</div>
+                                      <div class="term-dates">Wed 21 Apr 2021 &ndash; Fri 2 Jul 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">3</span>2020</div>
-                                      <div class="term-dates">Mon 20 Jul 2020 &ndash; Fri 25 Sep 2020</div>
+                                      <div class="term-name">Term<span class="number">3</span>2021</div>
+                                      <div class="term-dates">Tue 20 Jul 2021 &ndash; Fri 24 Sep 2021 <span class="note">Colleges start on Mon 19 July.</span></div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">4</span>2020</div>
-                                      <div class="term-dates">Mon 12 Oct 2020 &ndash; Thu 17 Dec 2020<span class="note">Teachers finish Fri 18 December, College teachers finish Fri 11 Dec 2020</span></div>
+                                      <div class="term-name">Term<span class="number">4</span>2021</div>
+                                      <div class="term-dates">Mon 11 Oct 2021 &ndash; Thu 16 Dec 2021<span class="note">Check with your college to confirm finish date.</span></div>
                                     </li>
                                   </ul>
                                   <div class="back-to-top"><a href="school-term-dates.html#top">Go to top</a></div>

--- a/site/public/about-australia/special-dates-and-events/school-term-dates.html
+++ b/site/public/about-australia/special-dates-and-events/school-term-dates.html
@@ -442,23 +442,23 @@
                                   <h2 id="nsw">New South Wales</h2>
                                   <div class="date-source">Source: <p><a href="https://education.nsw.gov.au/public-schools/going-to-a-public-school/calendars">https://education.nsw.gov.au/public-schools/going-to-a-public-school/calendars</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="school-terms nsw-2020">
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">1</span>2020</div>
-                                      <div class="term-dates">Tue 4 Feb 2020 &ndash; Thu 9 Apr 2020<span class="note">Eastern Division, Teachers commence Tue 28 January 2020.</span></div>
+                                      <div class="term-name">Term<span class="number">1</span>2021</div>
+                                      <div class="term-dates">Wed 3 Feb 2021 &ndash; Thu 1 Apr 2021<span class="note">Eastern Division, commences Wed 27 January 2021.</span></div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">2</span>2020</div>
-                                      <div class="term-dates">Mon 27 Apr 2020 &ndash; Fri 3 Jul 2020</div>
+                                      <div class="term-name">Term<span class="number">2</span>2021</div>
+                                      <div class="term-dates">Mon 19 Apr 2021 &ndash; Fri 25 Jun 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">3</span>2020</div>
-                                      <div class="term-dates">Mon 20 Jul 2020 &ndash; Fri 25 Sep 2020</div>
+                                      <div class="term-name">Term<span class="number">3</span>2021</div>
+                                      <div class="term-dates">Mon 12 Jul 2021 &ndash; Fri 17 Sep 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">4</span>2020</div>
-                                      <div class="term-dates">Mon 12 Oct 2020 &ndash; Fri 18 Dec 2020</div>
+                                      <div class="term-name">Term<span class="number">4</span>2021</div>
+                                      <div class="term-dates">Tue 5 Oct 2021 &ndash; Fri 17 Dec 2021</div>
                                     </li>
                                   </ul>
                                   <div class="back-to-top"><a href="school-term-dates.html#top">Go to top</a></div>

--- a/site/public/about-australia/special-dates-and-events/school-term-dates.html
+++ b/site/public/about-australia/special-dates-and-events/school-term-dates.html
@@ -415,23 +415,23 @@
                                   <h2 id="act">Australian Capital Territory</h2>
                                   <div class="date-source">Source: <p><a href="https://www.education.act.gov.au/public-school-life/term_dates_and_public_holidays">https://www.education.act.gov.au/public-school-life/term_dates_and_public_holidays</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="school-terms act-2020">
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">1</span>2020</div>
-                                      <div class="term-dates">Mon 3 Feb 2020 &ndash; Thu 9 Apr 2020<span class="note">Students commence Tuesday 4 February 2020.</span></div>
+                                      <div class="term-name">Term<span class="number">1</span>2021</div>
+                                      <div class="term-dates">Mon 1 Feb 2021 &ndash; Thu 1 Apr 2021<span class="note">New students start Tue 1 Feb. Continuing students return Tue 2 Feb.</span></div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">2</span>2020</div>
-                                      <div class="term-dates">Mon 27 Apr 2020 &ndash; Fri 3 Jul 2020</div>
+                                      <div class="term-name">Term<span class="number">2</span>2021</div>
+                                      <div class="term-dates">Mon 19 Apr 2021 &ndash; Fri 25 Jun 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">3</span>2020</div>
-                                      <div class="term-dates">Mon 20 Jul 2020 &ndash; Fri 25 Sep 2020</div>
+                                      <div class="term-name">Term<span class="number">3</span>2021</div>
+                                      <div class="term-dates">Mon 12 Jul 2021 &ndash; Fri 17 Sep 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">4</span>2020</div>
-                                      <div class="term-dates">Mon 12 Oct 2020 &ndash; Fri 18 Dec 2020</div>
+                                      <div class="term-name">Term<span class="number">4</span>2021</div>
+                                      <div class="term-dates">Mon 5 Oct 2021 &ndash; Fri 17 Dec 2021</div>
                                     </li>
                                   </ul>
                                   <div class="back-to-top"><a href="school-term-dates.html#top">Go to top</a></div>

--- a/site/public/about-australia/special-dates-and-events/school-term-dates.html
+++ b/site/public/about-australia/special-dates-and-events/school-term-dates.html
@@ -604,23 +604,23 @@
                                   <h2 id="wa">Western Australia</h2>
                                   <div class="date-source">Source: <p><a href="https://www.education.wa.edu.au/future-term-dates/">https://www.education.wa.edu.au/future-term-dates/</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="school-terms wa-2020">
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">1</span>2020</div>
-                                      <div class="term-dates">Mon 3 Feb 2020 &ndash; Thu 9 Apr 2020</div>
+                                      <div class="term-name">Term<span class="number">1</span>2021</div>
+                                      <div class="term-dates">Mon 1 Feb 2021 &ndash; Thu 1 Apr 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">2</span>2020</div>
-                                      <div class="term-dates">Tue 28 Apr 2020 &ndash; Fri 3 Jul 2020</div>
+                                      <div class="term-name">Term<span class="number">2</span>2021</div>
+                                      <div class="term-dates">Mon 19 Apr 2021 &ndash; Fri 2 Jul 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">3</span>2020</div>
-                                      <div class="term-dates">Mon 20 Jul 2020 &ndash; Fri 25 Sep 2020</div>
+                                      <div class="term-name">Term<span class="number">3</span>2021</div>
+                                      <div class="term-dates">Mon 19 Jul 2021 &ndash; Fri 24 Sep 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">4</span>2020</div>
-                                      <div class="term-dates">Mon 12 Oct 2020 &ndash; Thu 17 Dec 2020</div>
+                                      <div class="term-name">Term<span class="number">4</span>2021</div>
+                                      <div class="term-dates">Mon 11 Oct 2021 &ndash; Thu 16 Dec 2021</div>
                                     </li>
                                   </ul>
                                   <div class="back-to-top"><a href="school-term-dates.html#top">Go to top</a></div>

--- a/site/public/about-australia/special-dates-and-events/school-term-dates.html
+++ b/site/public/about-australia/special-dates-and-events/school-term-dates.html
@@ -577,23 +577,23 @@
                                   <h2 id="vic">Victoria</h2>
                                   <div class="date-source">Source: <p><a href="https://www.education.vic.gov.au/about/department/Pages/datesterm.aspx">https://www.education.vic.gov.au/about/department/Pages/datesterm.aspx</a></p>
                                   </div>
-                                  <h3>2020</h3>
+                                  <h3>2021</h3>
                                   <ul class="school-terms vic-2020">
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">1</span>2020</div>
-                                      <div class="term-dates">Tue 28 Jan 2020 &ndash; Fri 27 Mar 2020<span class="note">First day of Term 1 is a student-free day.</span></div>
+                                      <div class="term-name">Term<span class="number">1</span>2021</div>
+                                      <div class="term-dates">Wed 27 Jan 2021 &ndash; Thu 1 Apr 2021<span class="note">First day of Term 1 is a student-free day.</span></div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">2</span>2020</div>
-                                      <div class="term-dates">Tue 14 Apr 2020 &ndash; Fri 26 Jun 2020</div>
+                                      <div class="term-name">Term<span class="number">2</span>2021</div>
+                                      <div class="term-dates">Mon 19 Apr 2021 &ndash; Fri 26 Jun 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">3</span>2020</div>
-                                      <div class="term-dates">Mon 13 Jul 2020 &ndash; Fri 18 Sep 2020</div>
+                                      <div class="term-name">Term<span class="number">3</span>2021</div>
+                                      <div class="term-dates">Mon 12 Jul 2021 &ndash; Fri 17 Sep 2021</div>
                                     </li>
                                     <li class="school-term">
-                                      <div class="term-name">Term<span class="number">4</span>2020</div>
-                                      <div class="term-dates">Mon 5 Oct 2020 &ndash; Fri 18 Dec 2020</div>
+                                      <div class="term-name">Term<span class="number">4</span>2021</div>
+                                      <div class="term-dates">Mon 4 Oct 2021 &ndash; Fri 17 Dec 2021</div>
                                     </li>
                                   </ul>
                                   <div class="back-to-top"><a href="school-term-dates.html#top">Go to top</a></div>

--- a/site/public/about-australia/special-dates-and-events/school-term-dates.html
+++ b/site/public/about-australia/special-dates-and-events/school-term-dates.html
@@ -45,7 +45,7 @@
   <link rel="apple-touch-icon" sizes="152x152" href="/profiles/gsecms/themes/ausgovau_bootstrap/favicons/apple-touch-icon-152x152.png">
   <link rel="apple-touch-icon" sizes="180x180" href="/profiles/gsecms/themes/ausgovau_bootstrap/favicons/apple-touch-icon-180x180.png">
   <link rel="icon" type="image/png" href="/profiles/gsecms/themes/ausgovau_bootstrap/favicons/favicon-32x32.png" sizes="32x32">
-  
+
   <link rel="icon" type="image/png" href="/profiles/gsecms/themes/ausgovau_bootstrap/favicons/favicon-96x96.png" sizes="96x96">
   <link rel="icon" type="image/png" href="/profiles/gsecms/themes/ausgovau_bootstrap/favicons/favicon-16x16.png" sizes="16x16">
   <link rel="manifest" href="/profiles/gsecms/themes/ausgovau_bootstrap/favicons/manifest.json">


### PR DESCRIPTION
All the dates  on the public holidays and school term pages have been updated from 2020 to 2021.

Closes #451 
Closes #452 